### PR TITLE
Fix bower parse error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "react": "~0.13.3",
     "reflux": "~0.2.7",
     "underscore": "~1.8.3",
-    "react-router": "~0.13.3",
+    "react-router": "~0.13.3"
   }
 }


### PR DESCRIPTION
extra comma was breaking the bower install.

Nice react Europe presentation. Looks super cool.
