### PR TITLE
Add Twitter Bootstrap to Bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "react": "~0.13.3",
     "reflux": "~0.2.7",
     "underscore": "~1.8.3",
-    "react-router": "~0.13.3"
+    "react-router": "~0.13.3",
+    "bootstrap": "~3.3.5"
   }
 }


### PR DESCRIPTION
Index.html tries to load Bootstrap styles, but these are missing from the Bower install
